### PR TITLE
slight fix to the LANG_ID of Bosnian

### DIFF
--- a/languages/bosnian.lng
+++ b/languages/bosnian.lng
@@ -12,7 +12,7 @@
 
 // Translation metadata
 // (use the English alphabet)
-LANG_ID                     "ba_BA"                   // language code & country according to ISO 639-1 & ISO 3166-1, respectively
+LANG_ID                     "bs_BS"                   // language code & country according to ISO 639-1 & ISO 3166-1, respectively
 LANG_NAME                   "Bosanski"                // language name
 LANG_AUTHOR                 "SecularSteve"            // translation author
 LANG_LASTUPDATE             "2020-01-09"              // date format: yyyy-mm-dd


### PR DESCRIPTION
It was _bs, not _ba