### PR TITLE
CMakeLists.txt: Fix executable install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,7 +661,7 @@ SET_TARGET_PROPERTIES(${GAME_UNIXNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CM
 # Installing on *nix
 IF(UNIX)
   INSTALL(CODE "MESSAGE(\"Installing ${GAME_NAME} ${GAME_VERSION}... Make sure that you have the appropriate privileges.\")")
-  INSTALL(TARGETS "${GAME_UNIXNAME}" RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}")
+  INSTALL(TARGETS "${GAME_UNIXNAME}" RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin/")
   INSTALL(FILES LICENSE README.md CHANGES.md logo.png surge.png surge.rocks DESTINATION "${GAME_DATADIR}")
   INSTALL(DIRECTORY characters scripts sprites config images levels musics quests samples scripts themes languages fonts licenses DESTINATION "${GAME_DATADIR}" PATTERN ".git" EXCLUDE)
   INSTALL(FILES src/misc/opensurge.png DESTINATION "${DESKTOP_ICON_PATH}")


### PR DESCRIPTION
This installs the unix executable into a `$PREFIX/bin` folder so it is present into the PATH.