### PR TITLE
Add a Polish translation

### DIFF
--- a/languages/polish.lng
+++ b/languages/polish.lng
@@ -1,0 +1,277 @@
+// -----------------------------------------------------------------------------
+// File: languages/polish.lng
+// Description: Polish translation (encoding: UTF-8)
+// Author: Artur "suve" Iwicki (veg@svgames.pl)
+// License: MIT
+// -----------------------------------------------------------------------------
+
+
+//
+// Section: generic
+//
+
+// Translation metadata
+// (use the English alphabet)
+LANG_ID                     "pl_PL"                   // language code & country according to ISO 639-1 & ISO 3166-1, respectively
+LANG_NAME                   "Polski"                  // language name
+LANG_AUTHOR                 "suve"                    // translation author
+LANG_LASTUPDATE             "2020-05-10"              // date format: yyyy-mm-dd
+LANG_COMPATIBILITY          "0.5.1.2"                 // required engine version
+
+
+
+//
+// Translators:
+//
+// Before starting your work, please check out the
+// Translation Guide at http://opensurge2d.org/wiki
+//
+// You don't need to translate everything exactly "as is".
+// You may use some "cool" slang that kids use, provided
+// that it's innofensive and that the meaning of what
+// you're translating is preserved!
+//
+// After translating, please make sure you test everything.
+// All texts should fit within their graphical boundaries.
+// To help you with the testing, use the developer mode.
+//
+// In the options screen, highlight the Stage select option.
+// Next, press RIGHT 3 times and enter. You'll see a list
+// of all the level files.
+//
+
+//
+// Updating translations:
+//
+// New strings get added from time to time. They are marked
+// as -- FIXME -- To find them, you may use a Find tool in
+// your text editor.
+//
+// Found something? Please search for it now.
+//
+// If you find that mark anywhere in the file, it means that
+// the translation needs to be updated. Please submit a patch
+// to keep it up to date.
+//
+// After translating the new strings, make sure to remove
+// that mark.
+//
+
+
+
+//
+// Section: menus
+//
+
+// Options
+OPTIONS_TITLE               "<color=$COLOR_TITLE>USTAWIENIA</color>"
+OPTIONS_YES                 "TAK"
+OPTIONS_NO                  "NIE"
+OPTIONS_GRAPHICS            "GRAFIKA"
+OPTIONS_FULLSCREEN          "Tryb pełnoekranowy"
+OPTIONS_RESOLUTION          "Skalowanie"
+OPTIONS_RESOLUTION_OPT1     "1X"
+OPTIONS_RESOLUTION_OPT2     "2X"
+OPTIONS_RESOLUTION_OPT3     "3X"
+OPTIONS_RESOLUTION_OPT4     "4X"
+OPTIONS_SMOOTHGFX           "Wygładzanie grafiki"
+OPTIONS_SMOOTHGFX_ERROR     "[tylko w trybie 32bpp]"
+OPTIONS_FPS                 "Licznik FPS"
+OPTIONS_GAME                "GRA"
+OPTIONS_GAMEPAD             "Używaj gamepada"
+OPTIONS_LANGUAGE            "Zmień język"
+OPTIONS_STAGESELECT         "Wybierz poziom"
+OPTIONS_CREDITS             "Autorzy Open Surge"
+OPTIONS_DONATE              "Przekaż darowiznę dla Open Surge"
+OPTIONS_BACK                "WSTECZ"
+
+// Stage Select
+STAGESELECT_TITLE           "<color=$COLOR_TITLE>WYBÓR POZIOMU</color>"
+STAGESELECT_DEBUG           "<color=$COLOR_TITLE>TRYB DEVELOPERSKI</color>"
+STAGESELECT_MSG             "Wciśnij <color=$COLOR_HIGHLIGHT>$INPUT_FIRE4</color>, by wyjść"
+STAGESELECT_PAGE            "strona $1/$2"
+STAGESELECT_ACT             "Etap"
+
+// Quest Select
+QUESTSELECT_TITLE           "<color=$COLOR_TITLE>WYBÓR ZADANIA</color>"
+QUESTSELECT_MSG             "Wciśnij <color=$COLOR_HIGHLIGHT>$INPUT_FIRE4</color>, by wyjść"
+QUESTSELECT_PAGE            "strona $1/$2"
+QUESTSELECT_INFO            "<color=$COLOR_HIGHLIGHT>Wersja:</color> $1\n<color=$COLOR_HIGHLIGHT>Autor:</color> $2\n<color=$COLOR_HIGHLIGHT>Opis:</color> $3"
+
+// Credits
+CREDITS_TITLE               "<color=$COLOR_TITLE>AUTORZY</color>"
+CREDITS_BACK                "Wciśnij <color=$COLOR_HIGHLIGHT>$INPUT_FIRE4</color>, by wyjść"
+CREDITS_HEADER              "<color=$COLOR_HIGHLIGHT>$GAME_NAME, wersja $GAME_VERSION</color>\nnapędzana przez $ENGINE_NAME\n$ENGINE_WEBSITE"
+CREDITS_ACTIVE              "<color=$COLOR_HIGHLIGHT>Ludzie</color>"
+CREDITS_THANKS              "<color=$COLOR_HIGHLIGHT>Podziękowania dla</color>"
+CREDITS_ALEXANDRE           "Założyciel projektu\nGłówny programista"
+CREDITS_JOAO                "Artysta"
+CREDITS_MATEUS              "Efekty dźwiękowe"
+CREDITS_CODY                "Grafiki koncepcyjne"
+CREDITS_JOHAN               "Muzyk (spoczywaj w pokoju, przyjacielu)"
+CREDITS_DI                  "Muzyk"
+CREDITS_VICTOR              "Muzyk"
+CREDITS_COLIN               "Sprite'y, scenariusz"
+CREDITS_BRIAN               "Rysownik sprite'ów"
+CREDITS_TRANSLATOR          "Tłumacz"
+CREDITS_TRANSLATORS         "Tłumaczenia"
+CREDITS_RES_TITLE           "<color=$COLOR_HIGHLIGHT>Autorzy poszczególnych plików</color>"
+CREDITS_RES_TEXT            "O ile nie zaznaczono inaczej, pliki wylistowane poniżej podlegają pod licencję Creative Commons Attribution 3.0 (CC-BY 3.0)."
+CREDITS_RES_IMAGES          "<color=$COLOR_HIGHLIGHT>Grafika</color>"
+CREDITS_RES_MUSICS          "<color=$COLOR_HIGHLIGHT>Muzyka</color>"
+CREDITS_RES_SAMPLES         "<color=$COLOR_HIGHLIGHT>Dźwięki</color>"
+CREDITS_RES_SCRIPTS         "<color=$COLOR_HIGHLIGHT>Skrypty</color>"
+CREDITS_RES_SCRIPTS_TEXT    "Autorzy wymienieni zostali wewnątrz skryptów."
+
+// Main Menu
+MAINMENU_TITLE              "MENU"
+MAINMENU_PLAY               "GRAJ"
+MAINMENU_CREATE             "TWÓRZ"
+MAINMENU_SHARE              "PODAJ DALEJ"
+MAINMENU_OPTIONS            "USTAWIENIA"
+MAINMENU_QUIT               "WYJDŹ"
+MAINMENU_DEVBUILD           "Wersja developerska"
+MAINMENU_VERSION            "v. $GAME_VERSION" // abbreviated
+
+// Create Menu
+// Note: when translating CREATEMENU_TEXT, make sure the text fits the screen! (6 lines max)
+CREATEMENU_TITLE            "TWÓRZ"
+CREATEMENU_PLAY             "ZOBACZ DEMO"
+CREATEMENU_LEARN            "UCZ SIĘ"
+CREATEMENU_SCRIPTING        "SURGESCRIPT"
+CREATEMENU_BACK             "WSTECZ"
+CREATEMENU_TEXT             "Open Surge pozwala Ci tworzyć własne, niesamowite gry! Uwolnij swoją kreatywność!\n\nRozpocznij swój własny projekt! Twórz nowe poziomy, przedmioty, postacie - i więcej! Wypróbuj edytor poziomów, naucz się obsługi silnika i wykorzystaj SurgeScript dla maksimum efektu!"
+
+// Congratulations Screen
+// Note: when translating CONGRATULATIONS_TEXT, make sure the text fits the screen! (6 lines max)
+CONGRATULATIONS_TITLE       "DZIĘKI ZA GRĘ"
+CONGRATULATIONS_SHARE       "PODAJ DALEJ"
+CONGRATULATIONS_DONATE      "ZRÓB DONATE"
+CONGRATULATIONS_BACK        "WSTECZ"
+CONGRATULATIONS_TEXT        "Dziękujemy Ci za grę w Open Surge, wersję $GAME_VERSION.\nChcesz grać dalej? Odwiedź $GAME_WEBSITE po nowości!\n\nOpen Surge pozwala Ci grać, ale także tworzyć własne gry. Jest tworzone przez ludzi takich, jak Ty! Podziel się radością - opowiedz swoim znajomym i rodzinie!"
+
+
+
+//
+// Section: input devices
+//
+
+// keyboard
+INPUT_KEYB_DIRECTIONAL      "STRZAŁKI"
+INPUT_KEYB_LEFT             "strzałka w LEWO"
+INPUT_KEYB_RIGHT            "strzałka w PRAWO"
+INPUT_KEYB_UP               "strzałka w GÓRĘ"
+INPUT_KEYB_DOWN             "strzałka w DÓŁ"
+INPUT_KEYB_FIRE1            "SPACJA"
+INPUT_KEYB_FIRE2            "LEWY CTRL"
+INPUT_KEYB_FIRE3            "ENTER"
+INPUT_KEYB_FIRE4            "ESCAPE"
+INPUT_KEYB_FIRE5            "W"
+INPUT_KEYB_FIRE6            "A"
+INPUT_KEYB_FIRE7            "S"
+INPUT_KEYB_FIRE8            "D"
+
+// joystick
+INPUT_JOY_DIRECTIONAL       "D-PAD"
+INPUT_JOY_LEFT              "przycisk W LEWO"
+INPUT_JOY_RIGHT             "przycisk W PRAWO"
+INPUT_JOY_UP                "przycisk W GÓRĘ"
+INPUT_JOY_DOWN              "przycisk W DÓŁ"
+INPUT_JOY_FIRE1             "PRZYCISK 1"
+INPUT_JOY_FIRE2             "PRZYCISK 2"
+INPUT_JOY_FIRE3             "PRZYCISK 3"
+INPUT_JOY_FIRE4             "PRZYCISK 4"
+INPUT_JOY_FIRE5             "PRZYCISK 5"
+INPUT_JOY_FIRE6             "PRZYCISK 6"
+INPUT_JOY_FIRE7             "PRZYCISK 7"
+INPUT_JOY_FIRE8             "PRZYCISK 8"
+
+
+
+//
+// Section: general gameplay
+//
+
+// Quit game? confirm box
+QUIT_QUESTION               "CZY NA PEWNO CHCESZ WYJŚĆ?"
+QUIT_OPTION1                "TAK"
+QUIT_OPTION2                "NIE"
+
+// Loading Screen
+LOADING_TEXT                "wczytywanie..."
+
+
+
+//
+// Section: levels
+//
+
+// Demo Level
+LEV_DEMO_1                  "<color=$COLOR_TITLE>Jak grać</color>\nWitaj w <color=$COLOR_HIGHLIGHT>poziomie demo Open Surge</color>!\nUżyj $INPUT_DIRECTIONAL aby się poruszać, oraz $INPUT_FIRE1, by skakać. $INPUT_FIRE2 zmienia aktywną postać."
+LEV_DEMO_2                  "<color=$COLOR_TITLE>Czy wiesz, że...?</color>\nWszystko w Open Surge jest edytowalne! Możesz tworzyć poziomy, przedmioty, postacie, wrogów - i więcej!\nTo pełny <color=$COLOR_HIGHLIGHT>system tworzenia gier</color>."
+LEV_DEMO_3                  "<color=$COLOR_TITLE>Uwolnij swoją kreatywność!</color>\nJedną z kluczowych zalet Open Surge jest <color=$COLOR_HIGHLIGHT>SurgeScript</color>. To język skryptowy dla gier - za jego pomocą możesz zbudować co tylko zdołasz sobie wyobrazić!"
+LEV_DEMO_4                  "<color=$COLOR_TITLE>Czad!</color>\nCzujesz ekscytację? Sięgaj ku gwiazd! Odwiedź <color=$COLOR_HIGHLIGHT>$GAME_WEBSITE</color>, aby już dzisiaj zacząć tworzyć niesamowite gry!"
+LEV_DEMO_5                  "<color=$COLOR_TITLE>Spróbuj!</color>\nTeraz twoja kolej! <color=$COLOR_HIGHLIGHT>Naciśnij F12, by otworzyć edytor.</color> Następnie otwórz paletę przedmiotów i zacznij budować swój poziom! (Naciśnij F1, jeżeli potrzebujesz pomocy.)"
+
+//
+// Section: bitmap fonts
+//
+
+//
+// Translators:
+//
+// Since the game uses bitmap fonts, parts of
+// the translation don't accept special characters.
+//
+// This section doesn't accept language-specific
+// special characters.
+//
+// If a translation is not possible, you may
+// leave the following sentences in English.
+//
+// If translating is possible, adapt the
+// sentences as necessary.
+//
+
+// Heads-Up Display
+HUD_SCORE                   "Wynik"
+HUD_TIME                    "Czas"
+HUD_POWER                   "Energia"
+
+// Level Cleared animation
+CLEARED_LINE1               "UKONCZONO"
+CLEARED_LINE2               "ETAP $LEVEL_ACT"
+CLEARED_POWER               "Bonus za energie"
+CLEARED_TIME                "Bonus za czas"
+CLEARED_SCORE               "Wynik"
+
+// Game Over
+GAMEOVER_PART1              "GAME"
+GAMEOVER_PART2              "OVER"
+
+// Time Over
+TIMEOVER_PART1              "KONIEC"
+TIMEOVER_PART2              "CZASU"
+
+
+
+//
+// Section: special codes
+//
+
+//
+// Translators:
+//
+// Erase this section from your translation.
+// Language files other than English should
+// NOT include the codes below.
+//
+
+// Colors
+COLOR_TITLE                 "ff8800"
+COLOR_HIGHLIGHT             "ffee11"
+COLOR_HUD                   "ffff00"
+COLOR_HUDDANGER             "ff0000"
+
+// Backward compatibility
+HUD_COLLECTIBLES            "$HUD_POWER"


### PR DESCRIPTION
This changeset adds a Polish translation file.

One thing to note: in the credits, each person has a short text explaining their roles. Polish is a gendered language, i.e. almost all role/job names have two forms depending on the gender (kinda like "actor" and "actress" in English). I've used the male form for all of those. If I'm misgendering someone, please tell me and I'll change the appropriate text.