### PR TITLE
Repair support for Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@
 !.vscode/launch.json
 !.vscode/extensions.json
 
+# msvc
+.vs/
+CMakeSettings.json
+out/
+
 # vim
 [._]*.s[a-v][a-z]
 [._]*.sw[a-p]

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ surge.prefs
 !src/**
 screenshots/*.png
 iconwin.res
+*.pdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,8 +433,6 @@ SET(GAME_HEADERS
   src/entities/camera.h
   src/entities/character.h
   src/entities/entitymanager.h
-  src/entities/object_compiler.h
-  src/entities/object_vm.h
   src/entities/player.h
   src/entities/particle.h
   src/entities/renderqueue.h

--- a/src/misc/iconwin.rc
+++ b/src/misc/iconwin.rc
@@ -1,2 +1,2 @@
-ALLEGRO_ICON ICON "src/misc/opensurge.ico"
+ALLEGRO_ICON ICON "opensurge.ico"
 


### PR DESCRIPTION
With the changes proposed by this pull request, Open Surge should be able to build using a `clang` toolchain in Visual Studio.

@alemart Do you want me to try for complete compatibility for the `msvc` toolchain (the default Visual Studio compiler), or not? It would likely involve additional code and preprocessor macro adjustments.